### PR TITLE
Update environment file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,4 @@ npm-debug.log*
 /www
 
 /.env
-/src/environments/environment.ts
 /.vercel

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Want to see how the Ionic Secure Solutions Starter was made? [Follow along the s
 - Ionic Secure Solutions: [Auth Connect](https://ionic.io/products/auth-connect), [Identity Vault](https://ionic.io/products/identity-vault), [Secure Storage](https://ionic.io/products/secure-storage)
 
 ## How to Run
-> Note: Installing and running this app requires an Ionic Enterprise Native key from a [Ionic Standard or Ionic Enterprise subscription or trial](https://ionic.io/pricing), as well as an Auth0 App. 
+> Note: Installing and running this app requires an Ionic Enterprise Native key from a [Ionic Standard or Ionic Enterprise subscription or trial](https://ionic.io/pricing). 
+To use authentication, an Auth0 App is required. 
 
 
 __Want to try Ionic's Secure Solutions in your app?__ [Sign up for a free trial](https://dashboard.ionicframework.com/personal/apps?native_trial=1&utm_medium=referral&utm_source=git_hub&utm_campaign=is3_native_trial).
@@ -30,10 +31,13 @@ __Want to try Ionic's Secure Solutions in your app?__ [Sign up for a free trial]
 - Install the Ionic CLI: `npm install -g @ionic/cli`
 - Clone this repository: `git clone https://github.com/ionic-team/ionic-enterprise-starter.git`
 - Navigate to repo in a terminal: `cd ionic-enterprise-starter`
-- Add an Ionic Enterprise Native key into your `.bash_profile` file or as an Environment Variable on Windows: `export ENT_NATIVE_KEY="key_4e9d5..."`
-  - You can find your key under Native Solutions > Auth Connect > Get Started after creating an app in your [Ionic Hub](https://dashboard.ionicframework.com/). More details [here](https://ionic.io/docs/enterprise-starter/enterprise-key).
+- Add an Ionic Enterprise Native key as an Environment Variable using your preferred method:
+  - Add to Bash or Zsh configuration file
+  - Set in terminal with `export ENT_NATIVE_KEY="key_4e9d5..."`
+  - You can find your key in your [Ionic Hub](https://dashboard.ionicframework.com/) under "Native Plugin Keys" (Native Solutions > Auth Connect > Get Started for personal accounts). More details [here](https://ionic.io/docs/enterprise-starter/enterprise-key).
 - Install dependencies (this will fail if you don't have an Ionic Enterprise Native key): `npm i`
-- Set up your local environment file: `npm run prebuild:dev`
-- Update the `clientID` and domain within the `discoveryURL` in the `auth0Config` in your `environment.ts` file using your Auth0 App details. More details [here](https://ionic.io/docs/enterprise-starter/auth-connect#setup-auth-configs-in-the-app).
+- OPTIONAL: Update the `clientID` and domain within the `discoveryURL` in the `auth0Config` in your `environment.ts` file using your Auth0 App details.
+  - If you have `AUTH0_CLIENT_ID` and `AUTH0_DOMAIN` set as environment variables locally, you can run `npm run prebuild:dev` to update the file automatically. 
+  - This is required to log in to the app. More details [here](https://ionic.io/docs/enterprise-starter/auth-connect#setup-auth-configs-in-the-app).
 - Run locally in a browser: `ionic serve`
 - Deploy to a mobile device: See details [here](https://capacitorjs.com/docs/basics/workflow#testing-your-capacitor-app).

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 import { IonicAuthOptions } from '@ionic-enterprise/auth';
 
-const authOptions = {
+const auth0Config = {
   authConfig: 'auth0' as 'auth0',
   clientID: 'YOUR_AUTH0_CLIENT_ID',
   discoveryUrl: 'https://YOUR_AUTH0_DOMAIN/.well-known/openid-configuration',
@@ -12,16 +12,16 @@ const authOptions = {
   audience: '',
 };
 
-export const nativeAuthOptions: IonicAuthOptions = {
-  ...authOptions,
+export const auth0NativeConfig: IonicAuthOptions = {
+  ...auth0Config,
   redirectUri: 'myEnterpriseApp://callback',
   logoutUrl: 'myEnterpriseApp://login',
   platform: 'capacitor',
   iosWebView: 'private',
 };
 
-export const webAuthOptions: IonicAuthOptions = {
-  ...authOptions,
+export const auth0WebConfig: IonicAuthOptions = {
+  ...auth0Config,
   redirectUri: 'http://app.enterprise.com/callback',
   logoutUrl: 'http://app.enterprise.com/login',
   platform: 'web',


### PR DESCRIPTION
- Changes `environment.example.ts` to `environment.ts`
- Updates exports in `environment.ts` to match imports for authentication service
- Removes `environment.ts` from gitignore
- Updates README to reflect new run process based on update

This is to resolve an error that occurred when running `npm install && ionic serve` per the Native Solutions Wizard in the Ionic Hub due to a missing `environment.ts` file. This removes the need for the user to run `prebuild:dev` before `ionic serve`. 

It also updates the README to explain that running `prebuild:dev` will automatically update the `environment.ts` file with their Auth0 credentials if environment variables are set.